### PR TITLE
Disabled JSON

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 let package = Package(
     name: "Jobs",
 	dependencies: [
-		.Package(url: "https://github.com/vapor/core.git", majorVersion: 1),
-		.Package(url: "https://github.com/vdka/JSON", majorVersion: 0, minor: 16)
+		.Package(url: "https://github.com/vapor/core.git", majorVersion: 1)
+		//.Package(url: "https://github.com/vdka/JSON", majorVersion: 0, minor: 16)
 	]
 )

--- a/Sources/Helpers.swift
+++ b/Sources/Helpers.swift
@@ -1,4 +1,4 @@
-import JSON
+/*import JSON
 import Foundation
 
 //TODO(Brett): change implementation to C since foundation is broken on Linux
@@ -9,4 +9,4 @@ func parseJSONFile(path: String) throws -> JSON {
         options: [.allowComments, .omitNulls]
     )
     return json
-}
+}*/

--- a/Sources/JSON.swift
+++ b/Sources/JSON.swift
@@ -1,4 +1,4 @@
-import JSON
+/*import JSON
 
 extension JSON {
     func buildJob() throws -> Job? {
@@ -10,4 +10,4 @@ extension JSON {
         //continuing implementation.
         return nil
     }
-}
+}*/


### PR DESCRIPTION
People are having conflicts with Vapor's definition of JSON and vdka's. I'll just disable the import until JSON is done and I can get one/both of the packages to rename.