### PR TITLE
Always Queue Jobs

### DIFF
--- a/Sources/Jobs.swift
+++ b/Sources/Jobs.swift
@@ -169,10 +169,8 @@ public final class Jobs {
             errorCallback: errorCallback
         )
 
-        if autoStart {
-            job.isRunning = true
-            shared.queue(job, performNow: true)
-        }
+        job.isRunning = true
+        shared.queue(job, performNow: autoStart)
 
         return job
     }


### PR DESCRIPTION
Rationale: Jobs may be created, without wanting them to run as soon as their created - but still wanted to be added to the queue.