### PR TITLE
Added support for specifying duration in hours

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Jobs.add(interval: .seconds(4)) {
 ```
 
 ## Intervals ⏲
-The `Duration` enumeration currently supports `.seconds`, `.days` and `.weeks`.
+The `Duration` enumeration currently supports `.seconds`, `hours`, `.days` and `.weeks`.
 ```swift
 Jobs.add(interval: .days(5)) {
     print("See you every 5 days.")
@@ -40,6 +40,7 @@ Jobs.add(interval: .days(5)) {
 It's possible to create a `Duration` from an `Int` and a `Double`.
 ```swift
 10.seconds // `Duration.seconds(10)`
+4.hours // `Duration.hours(4)`
 2.days // `Duration.days(2)`
 3.weeks // `Duration.weeks(3)`
 ```

--- a/Sources/Duration+Extensions.swift
+++ b/Sources/Duration+Extensions.swift
@@ -3,6 +3,11 @@ extension Int {
 	public var seconds: Duration {
 		return .seconds(Double(self))
 	}
+	
+    /// Converts the integer into an enum representation of hours.    
+	public var hours: Duration {
+		return .hours(self)
+	}
 
     /// Converts the integer into an enum representation of days.
 	public var days: Duration {

--- a/Sources/Jobs.swift
+++ b/Sources/Jobs.swift
@@ -4,6 +4,7 @@ import Foundation
 /// Represents an amount of time.
 public enum Duration {
     case seconds(Double)
+    case hours(Int)
     case days(Int)
     case weeks(Int)
 }
@@ -14,6 +15,10 @@ extension Duration {
         switch self {
         case .seconds(let count):
             return count
+            
+        case .hours(let count):
+          let secondsInHour = 3_600
+          return Double(count * secondsInHour)
         
         case .days(let count):
             let secondsInDay = 86_400

--- a/Tests/JobsTests/jobsTests.swift
+++ b/Tests/JobsTests/jobsTests.swift
@@ -20,6 +20,9 @@ class JobsTests: XCTestCase {
         let fiveSeconds = Duration.seconds(5).unixTime
         XCTAssertEqual(fiveSeconds, 5.0)
         
+        let threeHours = Duration.hours(3).unixTime
+        XCTAssertEqual(threeHours, 10800.0)
+        
         let nineDays = Duration.days(9).unixTime
         XCTAssertEqual(nineDays, 777600.0)
         
@@ -30,6 +33,9 @@ class JobsTests: XCTestCase {
     func testDurationExtensions() {
         let seconds = 2.seconds
         XCTAssertEqual(seconds.unixTime, 2.0)
+        
+        let hours = 3.hours
+        XCTAssertEqual(hours.unixTime, 10800.0)
 
         let days = 9.days
         XCTAssertEqual(days.unixTime, 777600.0)


### PR DESCRIPTION
I often want to dispatch jobs every other hour or similar. Would be nice with support for specifying the intervals/duration in hours.

Let me know if you need any changes to this.